### PR TITLE
Support aadhaar_number as both number and string

### DIFF
--- a/src/src/facilitator/facilitator.service.ts
+++ b/src/src/facilitator/facilitator.service.ts
@@ -355,8 +355,11 @@ export class FacilitatorService {
 	}
 
 	async updateAadhaarDetails(id: number, body: any) {
-		const aadhaar_no = body.aadhar_no;
+		let aadhaar_no = body.aadhar_no;
 
+		if (typeof aadhaar_no === 'number') {
+			aadhaar_no = String(aadhaar_no);
+		}
 		if (
 			typeof aadhaar_no !== 'string' ||
 			!aadhaar_no.trim() ||


### PR DESCRIPTION
I fixed the issue of aadhaar_number saying invalid. It was occurring due to getting it as number type instead of string. I fixed and supported aadhaar_number as both number and string.