### PR TITLE
Task #203988 Do not allow to add duplicate Aadhaar if it added for Facilitator already

### DIFF
--- a/src/src/beneficiaries/beneficiaries.service.ts
+++ b/src/src/beneficiaries/beneficiaries.service.ts
@@ -1897,6 +1897,13 @@ export class BeneficiariesService {
 						aadhar_no: aadhaar_no,
 					});
 
+				if (hasuraResponse.data?.users?.some(user => user.program_faciltators[0]?.id)) {
+					return response.status(400).json({
+						success: false,
+						message: 'Sorry! You can not add this Aadhaar number!',
+					});
+				}
+
 				if (
 					hasuraResponse?.data?.users_aggregate?.aggregate.count >
 						0 &&

--- a/src/src/services/hasura/hasura.service.ts
+++ b/src/src/services/hasura/hasura.service.ts
@@ -133,7 +133,10 @@ export class HasuraService {
 			  aadhar_no
 			  program_beneficiaries{
 				facilitator_id
-			 }
+			  }
+			  program_faciltators {
+				id
+			  }
 			}}`,
 		};
 


### PR DESCRIPTION
Task: [System should not allow Facilitator to add duplicate Aadhaar number of beneficiary if that Aadhaar number is already added for any Facilitator](https://tracker.tekdi.net/issues/203988)

# I have ensured that following `Pull Request Checklist` is taken care of before sending this PR

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Code is formatted as per format decided
* [x] Updated acceptance criteria in tracker
* [x] Updated test cases in test-cases-tracker
* [x] Updated new API endpoint if any in common postman collection
* [x] Updated DB changes in db-tracker if any
