### PR TITLE
Task #203988 Added Aadhaar already registered for facilitator flag in is_user_exist API

### DIFF
--- a/src/src/modules/auth/auth.service.ts
+++ b/src/src/modules/auth/auth.service.ts
@@ -385,10 +385,17 @@ export class AuthService {
 			userExist.length > 0 &&
 			userRoles.includes('facilitator') &&
 			userExist.some(
+				(user) => user.program_beneficiaries[0]?.facilitator_id,
+			) &&
+			userExist.some(
 				(user) =>
 					user.program_beneficiaries[0]?.facilitator_id ==
 					tokenUserId,
 			);
+
+		const aadhaarRegisteredForFacilitator =
+			userExist.length > 0 &&
+			userExist.some((user) => user.program_faciltators[0]?.id);
 
 		// Check wheather user is exist or not based on response
 		if (userExist.length > 0) {
@@ -397,6 +404,8 @@ export class AuthService {
 				message: 'User exist',
 				data: {},
 				underSameFacilitator: underSameFacilitatorCond || false,
+				aadhaarRegisteredForFacilitator:
+					aadhaarRegisteredForFacilitator || false,
 			});
 		} else {
 			return response.status(200).send({


### PR DESCRIPTION
Task: [System should not allow Facilitator to add duplicate Aadhaar number of beneficiary if that Aadhaar number is already added for any Facilitator](https://tracker.tekdi.net/issues/203988)

# I have ensured that following `Pull Request Checklist` is taken care of before sending this PR

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Code is formatted as per format decided
* [x] Updated acceptance criteria in tracker
* [x] Updated test cases in test-cases-tracker
* [x] Updated new API endpoint if any in common postman collection
* [x] Updated DB changes in db-tracker if any
