### PR TITLE
Change in PCR Scores in create and update API

### DIFF
--- a/src/src/pcrscores/pcrscores.service.ts
+++ b/src/src/pcrscores/pcrscores.service.ts
@@ -51,9 +51,9 @@ export class PcrscoresService {
 			query: query,
 		});
 
-		let camp_id = result?.data?.group_users?.[0]?.camps?.id;
+		let camp_id = result?.data?.group_users?.[0]?.camps?.id || null;
 
-		response = await this.hasuraService.create(
+		response = await this.hasuraService.q(
 			this.table,
 			{
 				...body,
@@ -162,6 +162,7 @@ export class PcrscoresService {
 		let facilitator_id = request.mw_userid;
 		let user_id = body?.user_id;
 		let pcrscore_id = id;
+		body.camp_id = body?.camp_id || null;
 		let response;
 
 		let query = `query MyQuery {


### PR DESCRIPTION
Change in Create api
1 when beneficiaries is not in camp so send camp_id null and if camp_id is there it will take camp_id
change in update api
1. if camp_id is not send or remove camp id it will update null or camp id 

# I have ensured that following `Pull Request Checklist` is taken care of before sending this PR

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Code is formatted as per format decided
* [x] Updated acceptance criteria in tracker
* [x] Updated test cases in test-cases-tracker
* [x] Updated new API endpoint if any in common postman collection
* [x] Updated DB changes in db-tracker if any
