### PR TITLE
Task #212628 [BE] multiple reassign beneficiaries in camp

### DIFF
--- a/src/src/beneficiaries/beneficiaries.service.ts
+++ b/src/src/beneficiaries/beneficiaries.service.ts
@@ -3708,12 +3708,6 @@ export class BeneficiariesService {
 		beneficiaryDetails,
 		newFacilitatorId: number,
 	) {
-		const response = {
-			success: false,
-			data: null,
-			message: '',
-		};
-
 		let updateResult = [];
 		if (
 			Array.isArray(beneficiaryDetails) &&

--- a/src/src/camp/camp.controller.ts
+++ b/src/src/camp/camp.controller.ts
@@ -361,4 +361,21 @@ export class CampController {
 	) {
 		return this.campService.campLearnersById(id, body, request, response);
 	}
+
+	//multiple reassigne learner from One camp to other
+	@Patch('/admin/multiplereassign/:id')
+	@UseGuards(new AuthGuard())
+	multiplereassignBeneficiarytoCamp(
+		@Req() request: any,
+		@Body() body: any,
+		@Param('id') id: number,
+		@Res() response: any,
+	) {
+		return this.campService.multiplereassignBeneficiarytoCamp(
+			id,
+			body,
+			request,
+			response,
+		);
+	}
 }

--- a/src/src/user/user.service.ts
+++ b/src/src/user/user.service.ts
@@ -1248,10 +1248,11 @@ export class UserService {
 			newData,
 			tempArray,
 			action,
+			sortedData,
 		} = auditLogsObject;
 		let storeOld = {};
 		let storeNew = {};
-		if (!action || action != 'create') {
+		if (!action || (action != 'create' && !sortedData)) {
 			for (let data of tempArray) {
 				if (oldData[data] !== newData[data]) {
 					storeOld[data] = oldData[data];
@@ -1262,9 +1263,6 @@ export class UserService {
 			storeOld = oldData;
 			storeNew = newData;
 		}
-
-		console.log('storeOld', storeOld);
-		console.log('storeNew', storeNew);
 
 		if (
 			Object.keys(storeOld).length !== 0 &&

--- a/src/src/userauth/userauth.controller.ts
+++ b/src/src/userauth/userauth.controller.ts
@@ -11,6 +11,7 @@ import {
 	UseInterceptors,
 	UsePipes,
 	ValidationPipe,
+	Response,
 } from '@nestjs/common';
 
 import { UserauthService } from './userauth.service';


### PR DESCRIPTION
https://tracker.tekdi.net/issues/212628?issue_count=27&issue_position=8&next_issue_id=212283&prev_issue_id=212484
# I have ensured that following `Pull Request Checklist` is taken care of before sending this PR

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Code is formatted as per format decided
* [ ] Updated acceptance criteria in tracker
* [ ] Updated test cases in test-cases-tracker
* [ ] Updated new API endpoint if any in common postman collection
* [ ] Updated DB changes in db-tracker if any


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced the capability to update the facilitator IDs for multiple beneficiaries in a single operation.
	- Added functionality to reassign multiple learners from one camp to another seamlessly.
	- Enhanced camp management with new methods for bulk user data updates, including user reassignment and consent detail updates.

- **Refactor**
	- Improved the logic in the `UserService` for handling user data updates, enhancing performance and reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->