### PR TITLE
Bug #226455  [BE] : Prerak List | Incorrect Validation on Prerak list API and Bug #226457  [BE] : ADMIN | PC | Prerak list | Filter is not working for District and block

### DIFF
--- a/src/src/program-coordinator/program-coordinator.service.ts
+++ b/src/src/program-coordinator/program-coordinator.service.ts
@@ -1195,6 +1195,8 @@ export class ProgramCoordinatorService {
 				pb.academic_year_id, 
 				pb.status, 
 				pb.enrollment_number, 
+				pb.enrollment_first_name,
+				pb.enrollment_last_name,
 				u.first_name, 
 				u.last_name,
 				f.first_name AS facilitator_first_name, 

--- a/src/src/program-coordinator/program-coordinator.service.ts
+++ b/src/src/program-coordinator/program-coordinator.service.ts
@@ -339,8 +339,8 @@ export class ProgramCoordinatorService {
 
 				if (last_name?.length > 0) {
 					userFilter.push(`
-				first_name: { _ilike: "%${first_name}%" }, 
-			  last_name: { _ilike: "%${last_name}%" } 
+					first_name: { _ilike: "%${first_name}%" }, 
+					 last_name: { _ilike: "%${last_name}%" } 
 				  `);
 				} else {
 					userFilter.push(
@@ -348,17 +348,18 @@ export class ProgramCoordinatorService {
 					);
 				}
 			}
-
-			if (body.district) {
-				userFilter.push(`district: {_eq: "${body.district}"}`);
-			}
-			if (body.block) {
-				userFilter.push(`block: {_eq: "${body.block}"}`);
-			}
 		}
+
+		if (body.district) {
+			userFilter.push(`district: {_in: ["${body.district}"]}`);
+		}
+		if (body.block) {
+			userFilter.push(`block: {_in: ["${body.block}"]}`);
+		}
+
 		let filter = [];
 		if (userFilter.length > 0) {
-			filter.push(`user: {${userFilter.join(', ')}}`);
+			filter.push(` ${userFilter.join(', ')}`);
 		}
 
 		let filterQuery = filter.join(', ');
@@ -393,7 +394,7 @@ export class ProgramCoordinatorService {
 							path
 							}
 						program_users(where: {ip_user_id: {_eq:${ip_id}}, program_facilitators: {academic_year_id: {_eq:${academic_year_id}}, program_id: {_eq:${program_id}}}}) {
-								program_facilitators(where: {${filterQuery},academic_year_id:{_eq:${academic_year_id}},program_id:{_eq:${program_id}}}, limit: ${limit}, offset: ${offset})  {
+								program_facilitators(where: {user:{${filterQuery}},academic_year_id:{_eq:${academic_year_id}},program_id:{_eq:${program_id}}}, limit: ${limit}, offset: ${offset})  {
 										facilitator_id: user_id
 										id:id
 										status
@@ -415,7 +416,7 @@ export class ProgramCoordinatorService {
 								count
 						}
 				}
-				program_faciltators_aggregate(where:{pc_id:{_eq:${id}},academic_year_id:{_eq:${academic_year_id}},program_id:{_eq:${program_id}}}){
+				program_faciltators_aggregate(where:{user:{${filterQuery}},pc_id:{_eq:${id}},academic_year_id:{_eq:${academic_year_id}},program_id:{_eq:${program_id}}}){
 					aggregate{
 						count
 					}
@@ -466,8 +467,10 @@ export class ProgramCoordinatorService {
 		let users = [];
 		let facilitators = [];
 		let total_count =
-			hasura_response?.data?.users_aggregate?.aggregate?.count || 0;
+			hasura_response?.data?.program_faciltators_aggregate?.aggregate
+				?.count || 0;
 		const totalPages = Math.ceil(total_count / limit);
+
 		if (program_coordinator_data?.users) {
 			program_coordinator_data.users.forEach((user) => {
 				users.push({
@@ -986,19 +989,17 @@ export class ProgramCoordinatorService {
 		const page = isNaN(body?.page) ? 1 : parseInt(body?.page);
 		const limit = isNaN(body?.limit) ? 10 : parseInt(body?.limit);
 		let offset = page > 1 ? limit * (page - 1) : 0;
-
 		let hasura_response;
+		let userFilter = [`pc_id:{_eq:${pc_id}}`];
 
-		let userFilter = [];
-
+		if (body.withCampFilter == 'campFilter') {
+			userFilter.push(`user:{
+				group_users: {
+				status: {_eq: "active"},
+				member_type: {_eq: "owner"}
+			}}`);
+		}
 		//filters
-
-		userFilter.push(`pc_id:{_eq:${pc_id}},user:{
-      group_users: {
-      status: {_eq: "active"},
-      member_type: {_eq: "owner"}
-    }
-    }`);
 
 		if (body?.status) {
 			userFilter.push(`status:{_eq:${body?.status}}`);


### PR DESCRIPTION
https://tracker.tekdi.net/issues/226455
https://tracker.tekdi.net/issues/226457
### **User description**
# I have ensured that following `Pull Request Checklist` is taken care of before sending this PR

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Code is formatted as per format decided
* [ ] Updated acceptance criteria in tracker
* [ ] Updated test cases in test-cases-tracker
* [ ] Updated new API endpoint if any in common postman collection
* [ ] Updated DB changes in db-tracker if any


___

### **PR Type**
enhancement


___

### **Description**
- Enhanced filtering logic by changing district and block filters to use `_in` instead of `_eq`, allowing for more flexible queries.
- Improved the construction of filter queries by adjusting how user filters are incorporated, ensuring more accurate data retrieval.
- Updated the aggregation logic to use `program_faciltators_aggregate` for counting, aligning with the new filtering approach.
- Refined the initialization of user filters and conditionally added a camp filter when `withCampFilter` is set to 'campFilter'.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>program-coordinator.service.ts</strong><dd><code>Enhance filtering logic for district, block, and camp prerak list</code></dd></summary>
<hr>

src/src/program-coordinator/program-coordinator.service.ts

<li>Modified district and block filters to use <code>_in</code> instead of <code>_eq</code>.<br> <li> Adjusted filter query logic to include user filters more effectively.<br> <li> Updated the aggregation logic to use <code>program_faciltators_aggregate</code>.<br> <li> Refined user filter initialization and conditionally added camp <br>filter.<br>


</details>


  </td>
  <td><a href="https://github.com/tekdi/eg-backend/pull/1479/files#diff-e321103dc20fbd06cb427bed33f78e265c9e25dcba2f28306c324ab9479ce71c">+24/-23</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Improved user filtering capabilities, allowing for more flexible queries based on multiple district and block values.
  
- **Bug Fixes**
	- Adjusted logic for filtering users by first and last names for better formatting consistency.

- **Chores**
	- Minor formatting improvements and removal of redundant code for cleaner and more maintainable service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->