### PR TITLE
sonar issue solved

### DIFF
--- a/src/src/observations/observations.service.ts
+++ b/src/src/observations/observations.service.ts
@@ -168,14 +168,14 @@ export class ObservationsService {
 		if (newQdata > 0) {
 			return resp.status(422).json({
 				success: false,
-				message: 'Duplicate title encountered !',
+				message: 'Duplicate title encountered !!',
 				data: {},
 			});
 		}
 
 		let query = '';
 		Object.keys(body).forEach((e) => {
-			if (body[e] && body[e] != '') {
+			if (body[e] != '' && body[e]) {
 				if (e === 'render') {
 					query += `${e}: ${body[e]}, `;
 				} else if (Array.isArray(body[e])) {
@@ -252,7 +252,7 @@ export class ObservationsService {
 		if (newQdata > 0) {
 			return resp.status(422).json({
 				success: false,
-				message: 'Duplicate observation field encountered !',
+				message: 'Duplicate observation field encountered !!',
 				data: {},
 			});
 		}
@@ -335,7 +335,7 @@ export class ObservationsService {
 		if (newQdata > 0) {
 			return resp.status(422).json({
 				success: false,
-				message: 'Duplicate field responses encountered !',
+				message: 'Duplicate field responses encountered !!!',
 				data: {},
 			});
 		}
@@ -504,7 +504,7 @@ export class ObservationsService {
 		if (newQdata > 0) {
 			return resp.status(422).json({
 				success: false,
-				message: 'Duplicate title encountered !',
+				message: 'Duplicate title encountered !!!!',
 				data: {},
 			});
 		}

--- a/src/src/observations/observations.service.ts
+++ b/src/src/observations/observations.service.ts
@@ -163,9 +163,8 @@ export class ObservationsService {
 		const vresponse = await this.hasuraServiceFromServices.getData({
 			query: vquery,
 		});
-		const newQdata = vresponse?.data?.fields_aggregate?.aggregate?.count;
 
-		if (newQdata > 0) {
+		if (vresponse?.data?.fields_aggregate?.aggregate?.count > 0) {
 			return resp.status(422).json({
 				success: false,
 				message: 'Duplicate title encountered !!',

--- a/src/src/program-coordinator/program-coordinator.service.ts
+++ b/src/src/program-coordinator/program-coordinator.service.ts
@@ -116,8 +116,8 @@ export class ProgramCoordinatorService {
 
 			let data_to_create_user = {
 				enabled: 'true',
-				firstName: body?.first_name,
 				lastName: body?.last_name,
+				firstName: body?.first_name,
 				username: username,
 				credentials: [
 					{
@@ -138,8 +138,8 @@ export class ProgramCoordinatorService {
 				);
 
 				const registerUserRes = await this.keycloakService.registerUser(
-					data_to_create_user,
 					token.access_token,
+					data_to_create_user,
 				);
 
 				if (registerUserRes.error) {
@@ -162,8 +162,8 @@ export class ProgramCoordinatorService {
 				} else if (registerUserRes.headers.location) {
 					const split = registerUserRes.headers.location.split('/');
 					const keycloak_id = split[split.length - 1];
-					body.keycloak_id = keycloak_id;
 					body.username = data_to_create_user.username;
+					body.keycloak_id = keycloak_id;
 					body.password = password;
 					let role_id;
 


### PR DESCRIPTION
### **User description**
# I have ensured that following `Pull Request Checklist` is taken care of before sending this PR

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [ ] Code is formatted as per format decided
* [ ] Updated acceptance criteria in tracker
* [ ] Updated test cases in test-cases-tracker
* [ ] Updated new API endpoint if any in common postman collection
* [ ] Updated DB changes in db-tracker if any


___

### **PR Type**
bug_fix


___

### **Description**
- Fixed a condition check in the `ObservationsService` to ensure proper query construction by changing the order of checks for empty strings and null values.
- Updated error messages for duplicate entries to provide clearer feedback by adding additional exclamation marks.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>observations.service.ts</strong><dd><code>Fix condition check and update error messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/src/observations/observations.service.ts

<li>Fixed condition check in query construction.<br> <li> Updated error messages for duplicate entries.<br>


</details>


  </td>
  <td><a href="https://github.com/tekdi/eg-backend/pull/1505/files#diff-4d5def4d8bc8ba9603ec79aa164278b38552e9e9b6c3898d4c59ce3e10efdf57">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
	- Enhanced error messages for duplicate entries to emphasize urgency.
	- Updated messages for duplicate titles, observation fields, and field responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->