### PR TITLE
Bug #227149 [BE] Registred in neev camp learner reassing camp issue fix

### DIFF
--- a/src/src/camp/camp.service.ts
+++ b/src/src/camp/camp.service.ts
@@ -4383,7 +4383,8 @@ export class CampService {
 				learner_data?.find(
 					(item) =>
 						user_id === item.user_id &&
-						item.status !== 'registered_in_camp',
+						item.status !== 'registered_in_camp' &&
+						item.status !== 'registered_in_neev_camp',
 				),
 			)
 			.filter((e) => e);


### PR DESCRIPTION
### **User description**
https://tracker.tekdi.net/issues/227149

# I have ensured that following `Pull Request Checklist` is taken care of before sending this PR

<!-- Please keep this section. It will make the maintainer's life easier. -->

* [x] Code is formatted as per format decided
* [x] Updated acceptance criteria in tracker
* [x] Updated test cases in test-cases-tracker
* [x] Updated new API endpoint if any in common postman collection
* [x] Updated DB changes in db-tracker if any


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where learners registered in 'neev camp' were not reassigned correctly by updating the status check logic.
- Enhanced the condition to include 'registered_in_neev_camp' status in the learner status validation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>camp.service.ts</strong><dd><code>Fix learner reassignment issue by updating status check</code>&nbsp; &nbsp; </dd></summary>
<hr>

src/src/camp/camp.service.ts

<li>Added condition to check for 'registered_in_neev_camp' status.<br> <li> Enhanced learner status validation logic.<br>


</details>


  </td>
  <td><a href="https://github.com/tekdi/eg-backend/pull/1507/files#diff-c4a622014961b71cc26ee8353e6a58c23d112d4fe6055f4c64a8424666eeaed1">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

